### PR TITLE
Fix puppeteer HTTPS errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,12 @@ function slugify(url) {
 async function scrapeText(url) {
   const browser = await puppeteer.launch({
     headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    ignoreHTTPSErrors: true,
+    args: [
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      "--ignore-certificate-errors",
+    ],
   });
   const page = await browser.newPage();
   await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });


### PR DESCRIPTION
## Summary
- ignore TLS errors when scraping via puppeteer

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68400df42c38832a9303df9f45937ccb